### PR TITLE
Use nalgebra types in L-BFGS solver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Vladimir Pinchuk"]
 
 [dependencies]
 libm = "0.2.2"
-argmin = { version = "0.7.0", default-features = false }
-argmin-math = "0.2.0"
+argmin = { version = "0.6.0", default-features = false }
+argmin-math = { version = "0.1.0", default-features = false, features = ["nalgebra_v0_30"] }
 superslice = "1.0.0"
 nalgebra = "0.30"
 rayon = "1.5.3"


### PR DESCRIPTION
I noticed that you are using `Vec`s in L-BFGS, which forces you to convert your `DVector` to `Vec`. When activating the `nalgebra_v0_30` feature in `argmin-math` it is possible to use nalgebra types directly. This will also use nalgebra internally, which should be faster then using `Vec`s.

Unfortunately this forced me to downgrade argmin from 0.7 to 0.6 because of https://github.com/argmin-rs/argmin/issues/257 .
Once this is fixed it should be fairly straight-forward to upgrade to 0.7. 